### PR TITLE
[FEAT] Enforce Strong Password Requirements for User Authentication

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,3 +1,4 @@
+import { ThemeSwitcherButton } from '@/components/buttons/theme-switcher-button';
 import { Logo } from '@/components/logo';
 
 export default function AuthLayout({
@@ -9,6 +10,9 @@ export default function AuthLayout({
     <div className='flex flex-col min-h-svh w-full items-center justify-center p-6 md:p-10'>
       <Logo />
       <div className='w-full max-w-sm'>{children}</div>
+      <div className='fixed bottom-4 right-4 bg-background'>
+        <ThemeSwitcherButton />
+      </div>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,7 +45,14 @@ export default function RootLayout({
             {children}
           </ThemeProvider>
         </Provider>
-        <Toaster position='top-right' />
+        <Toaster
+          position='top-right'
+          toastOptions={{
+            classNames: {
+              description: '!text-foreground/80',
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/components/forms/forgot-password.tsx
+++ b/components/forms/forgot-password.tsx
@@ -29,7 +29,7 @@ import { forgetPassword } from '@/lib/auth-client';
 import { cn, getErrorMessage } from '@/lib/utils';
 
 const formSchema = z.object({
-  email: z.string().email('Invalid email address'),
+  email: z.string().trim().email('Invalid email address'),
 });
 
 export function ForgotPasswordForm({

--- a/components/forms/sign-in.tsx
+++ b/components/forms/sign-in.tsx
@@ -38,8 +38,11 @@ import { cn } from '@/lib/utils';
 import { PasswordInput } from '../password-input';
 
 const formSchema = z.object({
-  email: z.string().email('Invalid email address'),
-  password: z.string().min(8, 'Password must be at least 8 characters long'),
+  email: z.string().trim().email('Invalid email address'),
+  password: z
+    .string()
+    .trim()
+    .min(8, 'Password must be at least 8 characters long'),
   rememberMe: z.boolean(),
 });
 
@@ -58,6 +61,7 @@ export function SignInForm({
     },
   });
   const { isSubmitting } = form.formState;
+
   const [isPasswordVisible, setIsPasswordVisible] =
     useAtom(passwordVisibleAtom);
 

--- a/components/password-strength-indicator.tsx
+++ b/components/password-strength-indicator.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { Check, X } from 'lucide-react';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+import type { LucideProps } from 'lucide-react';
+
+export type PasswordStrengthLevel = 0 | 1 | 2 | 3 | 4;
+
+export interface PasswordStrengthIndicatorParams {
+  strength: PasswordStrengthLevel;
+  hasLength: boolean;
+  hasLowerAndUpper: boolean;
+  hasNumber: boolean;
+  hasSpecial: boolean;
+}
+
+const strengthStyle = {
+  0: null,
+  1: 'w-1/4 bg-red-400',
+  2: 'w-1/2 bg-gradient-to-r from-red-400 to-orange-400',
+  3: 'w-3/4 bg-gradient-to-r from-red-400 via-orange-400 to-yellow-400',
+  4: 'w-full bg-gradient-to-r from-red-400 via-orange-400 via-yellow-400 to-green-400',
+} as const;
+
+const strengthLevel = {
+  0: null,
+  1: 'very weak',
+  2: 'weak',
+  3: 'good',
+  4: 'strong',
+} as const;
+
+export const PasswordStrengthIndicator = ({
+  strength,
+  hasLength,
+  hasLowerAndUpper,
+  hasNumber,
+  hasSpecial,
+}: PasswordStrengthIndicatorParams) => {
+  return (
+    strength > 0 && (
+      <div className='flex flex-col'>
+        <div className='w-full h-2 bg-foreground/10 rounded-md overflow-hidden'>
+          <div className={cn('h-full rounded-md', strengthStyle[strength])} />
+        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <h5 className='text-sm text-foreground/50 w-max'>
+              strength : {strengthLevel[strength]}
+            </h5>
+          </TooltipTrigger>
+          <TooltipContent>
+            <div className='flex flex-nowrap flex-row justify-start items-center gap-1 w-full'>
+              <PasswordStrengthIndicatorIcon checked={hasLength} />
+              <h6>has more than 12 charactes</h6>
+            </div>
+            <div className='flex flex-nowrap flex-row justify-start items-center gap-1 w-full'>
+              <PasswordStrengthIndicatorIcon checked={hasLowerAndUpper} />
+              <h6>has both upper and lower lettrs included</h6>
+            </div>
+            <div className='flex flex-nowrap flex-row justify-start items-center gap-1 w-full'>
+              <PasswordStrengthIndicatorIcon checked={hasNumber} />
+              <h6>has numbers included</h6>
+            </div>
+            <div className='flex flex-nowrap flex-row justify-start items-center gap-1 w-full'>
+              <PasswordStrengthIndicatorIcon checked={hasSpecial} />
+              <h6>has specail characters included</h6>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    )
+  );
+};
+
+interface PasswordStrengthIndicatorIcon extends LucideProps {
+  checked: boolean;
+}
+const PasswordStrengthIndicatorIcon = ({
+  checked,
+  className,
+  ...props
+}: PasswordStrengthIndicatorIcon) =>
+  checked ? (
+    <Check className={cn('h-4 stroke-green-400', className)} {...props} />
+  ) : (
+    <X className={cn('h-4 stroke-red-400', className)} {...props} />
+  );

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,25 +1,25 @@
-"use client"
+'use client';
 
-import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner, ToasterProps } from 'sonner';
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { theme = 'system' } = useTheme();
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
-      className="toaster group"
+      theme={theme as ToasterProps['theme']}
+      className='toaster group'
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
         } as React.CSSProperties
       }
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Toaster }
+export { Toaster };

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import * as React from 'react';
+
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+import { cn } from '@/lib/utils';
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot='tooltip-provider'
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot='tooltip' {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot='tooltip-trigger' {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot='tooltip-content'
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          className,
+        )}
+        {...props}>
+        {children}
+        <TooltipPrimitive.Arrow className='bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]' />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -49,6 +49,7 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: true,
+    maxPasswordLength: 16,
     sendResetPassword: async ({ user, url: resetUrl }) => {
       console.log('Sending password reset email to : ', user);
       await sendEmail('passwordReset', user.email, {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,11 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+import type {
+  PasswordStrengthIndicatorParams,
+  PasswordStrengthLevel,
+} from '@/components/password-strength-indicator';
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
@@ -19,4 +24,64 @@ export const getErrorMessage = (error: unknown): string => {
   }
 
   return message;
+};
+
+/**
+ * Returns a password strength score between 0 and 4
+ * 0 = Empty
+ * 1 = Very Weak
+ * 2 = Weak
+ * 3 = Good
+ * 4 = Strong
+ */
+
+export const getPasswordStrength = (
+  password: string | null,
+): PasswordStrengthIndicatorParams => {
+  if (!password)
+    return {
+      strength: 0,
+      hasLength: false,
+      hasLowerAndUpper: false,
+      hasNumber: false,
+      hasSpecial: false,
+    };
+
+  let score = 0;
+
+  // Length check
+  if (password.length >= 12) score++;
+
+  // Character diversity
+  const hasLower = /[a-z]/.test(password);
+  const hasUpper = /[A-Z]/.test(password);
+
+  if (hasLower && hasUpper) {
+    score++;
+  }
+
+  const hasNumber = /\d/.test(password);
+  const hasSpecial = /[`~<>?,./!@#$%^&*()\-_=+"'|{}[\];:\\]/.test(password);
+
+  if (hasNumber) score++;
+  if (hasSpecial) score++;
+
+  // FOR DEBUGGING
+  // console.log('###--------- Passowrd Strength ---------###');
+  // console.table({
+  //   password,
+  //   score,
+  //   length: password.length,
+  //   hasLowerAndUpper: hasLower && hasUpper,
+  //   hasNumber,
+  //   hasSpecial,
+  // });
+
+  return {
+    strength: score as PasswordStrengthLevel,
+    hasLength: password.length >= 12,
+    hasLowerAndUpper: hasLower && hasUpper,
+    hasNumber,
+    hasSpecial,
+  };
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@react-email/components": "0.5.6",
     "@react-email/tailwind": "1.2.2",
     "better-auth": "^1.3.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.15)(react@19.1.0)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@react-email/components':
         specifier: 0.5.6
         version: 0.5.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1103,6 +1106,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -1173,6 +1189,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.1':
@@ -4402,6 +4431,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.15
 
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.15)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.15)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.15)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.15)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.15)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.15
+      '@types/react-dom': 19.1.9(@types/react@19.1.15)
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.15)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -4455,6 +4504,15 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.15
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.15
+      '@types/react-dom': 19.1.9(@types/react@19.1.15)
 
   '@radix-ui/rect@1.1.1': {}
 


### PR DESCRIPTION
## 🏗️ Background

<!-- Briefly describe the context and purpose of this pull request. -->
Enforce password strength requirements for user authentication. Currently, users can register with weak passwords — there is no enforcement for including numbers, uppercase letters, or special characters.

## 🧩 Related Issue

<!-- Link the issue this PR addresses. -->
Closes #13 

## ✅ Checklist

Please ensure the following before requesting a review:

- [x] Code follows linting rules (`pnpm lint`)
- [x] Code is properly formatted (`pnpm format`)
- [x] All tests pass (`pnpm test`)
- [x] Added/updated necessary documentation
- [x] Verified changes locally in development mode

## 💡 Additional Notes

<!-- Add any additional information or context for reviewers here. -->
<img width="467" height="706" alt="Screenshot 2025-10-22 at 11 20 40 PM" src="https://github.com/user-attachments/assets/aed90ac9-9522-4ffc-a0bc-34e2f9b85592" />
<img width="561" height="736" alt="Screenshot 2025-10-22 at 11 21 52 PM" src="https://github.com/user-attachments/assets/aaa76568-fc66-4963-bccf-642087732e59" />

